### PR TITLE
Wire frasermolyneux-copilot MCP server into repo

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,12 @@
 >
 > **Cloud agents (GitHub Copilot coding agent etc.):** read [`AGENTS.md`](../AGENTS.md) at the repo root first — it is the canonical brief that survives outside the local VS Code multi-root workspace.
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
 ## Project Overview
 
 Terraform-only repository that provisions portal environment infrastructure on Azure: App Configuration with Key Vault-backed secrets, API Management (consumption tier), Azure AD app registrations/service principals (Repository APIs v1/v2, Event Ingest, Servers Integration, Portal Bots, integration tests), SQL admin/reader/writer groups, managed identities with scoped role assignments, and a shared Key Vault for cross-cutting secrets.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,4 +32,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: npm ci && npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,14 @@ The `copilot-setup-steps.yml` workflow checks out `frasermolyneux/.github-copilo
 
 ---
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
+---
+
 ## Stack guardrails
 
 ### Tenant facts (always-on)

--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 ## Security
 
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+
+This repo is wired to the `frasermolyneux-copilot` MCP server (pinned to tag `v0.1.0` of [`frasermolyneux/.github-copilot`](https://github.com/frasermolyneux/.github-copilot)) so MCP-capable Copilot clients can query org conventions, instructions, prompts, and agents at runtime. The wiring lives in `.github/copilot/mcp_config.json` (consumed by the GitHub Copilot coding agent) and is built in CI by `.github/workflows/copilot-setup-steps.yml`. For the full tool surface, content-root resolution, local `.vscode/mcp.json` setup, and per-client wire-up snippets, see [`.github-copilot/mcp-server/README.md`](https://github.com/frasermolyneux/.github-copilot/blob/v0.1.0/mcp-server/README.md).


### PR DESCRIPTION
## Summary

Wires the `frasermolyneux-copilot` MCP server (pinned to tag `v0.1.0` of `frasermolyneux/.github-copilot`) into this repo so MCP-capable Copilot clients can query org instructions, prompts, and agents at runtime. Mirrors the pattern already merged into `portal-core`.

Closes #

## Type of change

- [ ] bugfix
- [ ] feature
- [ ] chore / refactor
- [x] docs
- [ ] infra (Terraform)
- [x] ci (GitHub Actions / Dependabot)
- [ ] dependencies
- [ ] breaking change

## Required reading consulted

- [x] `AGENTS.md` (repo brief)
- [x] `.github/copilot-instructions.md` (repo orientation)
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules)
- [ ] Stack-specific instruction files referenced in `AGENTS.md` (`standards.*`, `patterns.*`, `platform.*`, `shared.*`)

## Validation evidence

### Build

```text
N/A — no Terraform or application code touched. Only CI workflow + agent metadata files.
```

### Tests

```text
N/A — no test surface affected by docs + workflow + JSON config changes.
```

### Format check

```text
terraform fmt -check -recursive  →  N/A (no .tf files changed)

JSON parse: .github/copilot/mcp_config.json → ConvertFrom-Json OK; contains
  frasermolyneux-copilot entry with type/command/args/env/tools fields.

YAML parse: .github/workflows/copilot-setup-steps.yml → yaml.safe_load OK;
  contains pinned checkout (ref: refs/tags/v0.1.0), actions/setup-node@v6
  (node-version: 20.x), and Build MCP server step (npm ci && npm run build,
  working-directory: .github-copilot/mcp-server).
```

### Other (lint, terraform plan summary, screenshots)

Bootstrap snippet inserted into `AGENTS.md` and `.github/copilot-instructions.md` is byte-identical between the two files (SHA256 `30269e10f9d2b1ac9705e1021aac1b4c17d196104c7c53b428af60c0821ff023`, 1091 bytes LF-normalised) and matches the canonical source from `frasermolyneux/.github-copilot/.github/instructions/metadata.copilot-instructions.instructions.md` character-for-character.

## Risk and rollout

- **Blast radius:** Repo-local. Affects how Copilot agents discover org conventions when running here. No Azure resources, no app code, no Terraform state touched.
- **Auto-deploys on merge?** No. `copilot-setup-steps.yml` runs on its own trigger (workflow_dispatch + path-filtered push/PR on the workflow file itself). No deploy-dev / deploy-prd path is touched.
- **Manual steps post-merge:** None.
- **Rollback plan:** Revert this commit. The added `.github/copilot/` directory and the snippet sections are additive; reverting restores the pre-PR file shape with no orphan state.

## Reviewer focus areas

- `.github/workflows/copilot-setup-steps.yml` — confirm the pin (`ref: refs/tags/v0.1.0`) is acceptable and that you're happy with Node 20.x as the build runtime for the MCP server.
- `.github/copilot/mcp_config.json` — confirm relative paths (`.github-copilot/mcp-server/dist/index.js`, `GH_COPILOT_CONTENT_ROOT=.github-copilot`) match the layout produced by the workflow's checkout + build steps.
- Snippet placement: inserted near the top of `AGENTS.md` (between `## Required reading` and `## Stack guardrails`) and `.github/copilot-instructions.md` (between the leading blockquote and `## Project Overview`) so agents see it first. Shout if you'd prefer it lower in either file.

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified above in **Reviewer focus areas**
- [x] PR body cites each acceptance criterion from the linked issue
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced (`standards.oidc-and-secrets.instructions.md`)